### PR TITLE
Add trailing `/` for docs to correctly deduce the baseURL

### DIFF
--- a/codepipeline/functions/oui-index-resolver/index.js
+++ b/codepipeline/functions/oui-index-resolver/index.js
@@ -10,8 +10,28 @@ function handler(event) {
 
     if (event.request.uri[0] !== '/') parts.unshift('');
 
+    // With /1.0, without a trailing `/`, the docs confuse baseURL
+    if (/^\d+\.\d+$/.test(parts[1]) && parts.length === 2) {
+        parts.push('');
+        return {
+            statusCode: 308,
+            statusDescription: 'Permanent Redirect',
+            headers: {
+                "location": {
+                    "value": parts.join('/')
+                },
+                "cache-control": {
+                    "value": "max-age=604800"
+                },
+            }
+        };
+    }
+
     if (!/^\d+\.\d+$/.test(parts[1]) && (!USE_LATEST || parts[1] !== 'latest')) {
         parts.splice(1, 0, USE_LATEST ? 'latest' : LATEST_VERSION);
+
+        // If landing only with domain name, add trailing '/'
+        if (parts.length === 2) parts.push('');
 
         return {
             statusCode: 307,


### PR DESCRIPTION
### Description
With `/1.0`, the docs website thinks the baseURL is `/`. This change adds a trailing slash when a request arrives without one.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
